### PR TITLE
Update openapi.json - books tag

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -5,6 +5,12 @@
     "version": "1.0.0",
     "description": "API for managing books"
   },
+  "tags": [
+    {
+      "name": "books",
+      "description": "Provides operations to manage and retrieve books."
+    }
+  ],
   "servers": [
     {
       "url": "https://api6.angular-buch.com/"
@@ -13,6 +19,7 @@
   "paths": {
     "/books": {
       "get": {
+        "tags": ["books"],
         "summary": "Get the list of books or filtered list of books",
         "parameters": [
           {
@@ -57,6 +64,7 @@
         }
       },
       "post": {
+        "tags": ["books"],
         "summary": "Create a new book",
         "requestBody": {
           "required": true,
@@ -102,6 +110,7 @@
         }
       },
       "delete": {
+        "tags": ["books"],
         "summary": "Reset the book list to its initial state",
         "responses": {
           "200": {
@@ -112,6 +121,7 @@
     },
     "/books/{isbn}": {
       "get": {
+        "tags": ["books"],
         "summary": "Get a single book by ISBN",
         "parameters": [
           {
@@ -154,6 +164,7 @@
         }
       },
       "put": {
+        "tags": ["books"],
         "summary": "Update a book by ISBN",
         "parameters": [
           {
@@ -202,6 +213,7 @@
         }
       },
       "delete": {
+        "tags": ["books"],
         "summary": "Delete a book by ISBN",
         "parameters": [
           {


### PR DESCRIPTION
This adds a `books` tag to group all endpoints properly in Swagger UI and generated clients. Without it, everything ends up in a generic `DefaultService` (using OpenApi Codegen), which is very ugly.