### PR TITLE
Texte auf Deutsch übersetzen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # BookManager API v1
 
-This is the API for the BookManager application from the [German Angular Book](https://angular-buch.com). It is a RESTful API that provides CRUD operations for books.
-A publicly available server is hosted at [api1.angular-buch.com](https://api1.angular-buch.com).
+Dieses Projekt enthält eine HTTP-API für die BookManager-Anwendung aus dem [Angular-Buch](https://angular-buch.com).
+Die Schnittstelle bietet CRUD-Operationen für Buchdatensätze an.
+Ein öffentlich verfügbarer Server wird unter [api1.angular-buch.com](https://api1.angular-buch.com) gehostet.
 
 ## Installation
 
-> :warning: **You don't need to install this project to use the API. Please use the public server at [api1.angular-buch.com](https://api1.angular-buch.com).**
+> :warning: **Du musst dieses Projekt nicht installieren, um die API zu nutzen. Bitte verwende den öffentlichen Server unter [api1.angular-buch.com](https://api1.angular-buch.com).**
 
-The `public` folder must contain an `.env` file with MySQL credentials.
-Copy the `.env.example` to `.env`.
+Der Ordner `public` muss eine `.env`-Datei mit MySQL-Zugangsdaten enthalten.
+Kopiere die Datei `.env.example` nach `.env`.
 
-Dependencies are managed with composer. Run in the project root to install all deps:
+Abhängigkeiten werden mit Composer verwaltet. Führe im Projektverzeichnis den folgenden Befehl aus, um alle Abhängigkeiten zu installieren:
 
 ```bash
 composer install
@@ -18,6 +19,6 @@ composer install
 
 ## Swagger UI
 
-The `swagger-ui` package is installed as a dependency via `composer`.
-The served directory `public/swagger-ui` is a symlink to the `swagger-ui` package in the `vendor` folder.
-To be able to configure Swagger UI, an Apache rewrite rule replaces the predefined config with our own version (`public/swagger-initializer.js`).
+Das Paket `swagger-ui` wird als Abhängigkeit über `composer` installiert.
+Das bereitgestellte Verzeichnis `public/swagger-ui` ist ein Symlink auf das Paket `swagger-ui` im Ordner `vendor`.
+Um Swagger UI konfigurieren zu können, ersetzt eine Apache-Rewrite-Regel die vordefinierte Konfiguration durch unsere eigene Version (`public/swagger-initializer.js`).

--- a/public/dummycoverspage.php
+++ b/public/dummycoverspage.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
   <head>
     <title>BookManager API v1</title>
     <meta charset="UTF-8" />
@@ -7,9 +7,9 @@
     <link rel="stylesheet" href="media/style.css" media="screen" />
   </head>
   <body class="markdown-body">
-    <h1>Example Cover Images</h1>
+    <h1>Beispiel-Coverbilder</h1>
 
-    <p>We provide 30 dummy cover images to be used as cover image URLs in the book form.</p>
+    <p>Wir stellen 30 Beispiel-Coverbilder bereit, die du als Bild-URLs im Buchformular verwenden kannst.</p>
 
     <div class="image-container">
       <?php for ($i = 1; $i <= 30; $i++): ?>

--- a/public/indexpage.html
+++ b/public/indexpage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
   <head>
     <title>BookManager API v1</title>
     <meta charset="UTF-8" />
@@ -14,35 +14,33 @@
     </ul>
     <hr />
     <p>
-      <strong>You can reset the book list to its initial state.</strong
-      ><br />Execute this function if there are no more records or when the
-      contents are insufficient.
+      <strong>Du kannst die Buchliste zurücksetzen.</strong
+      ><br />Das ist z. B. sinnvoll, wenn keine Einträge mehr vorhanden sind.
     </p>
-    <button onclick="resetBookList()" id="reset">Reset book list</button>
+    <button onclick="resetBookList()" id="reset">Buchliste zurücksetzen</button>
     <span id="resetOK">OK</span>
     <hr />
     <p>
-      We provide <strong>hosted example cover images</strong> that can be used as Cover Image URLs in the book creation form.</strong>
+      Wir stellen <strong>gehostete Beispiel-Coverbilder</strong> bereit, die du als Bild-URLs im Buchformular verwenden kannst.
     </p>
     <p>
-      <strong><a href="/covers">&rarr; List of example cover images</a></strong>
+      <strong><a href="/covers">&rarr; Liste der Beispiel-Coverbilder</a></strong>
     </p>
     <hr />
-    <strong>Explorable API documentation:&nbsp;<a href="/swagger-ui/">/swagger-ui/</a></strong>
+    <strong>Interaktive API-Dokumentation:&nbsp;<a href="/swagger-ui/">/swagger-ui/</a></strong>
     <br />
-    <small>OpenAPI Specification:&nbsp;<a href="/openapi.json">/openapi.json</a></small>
+    <small>OpenAPI-Spezifikation:&nbsp;<a href="/openapi.json">/openapi.json</a></small>
     <hr />
-    &copy;&nbsp;<a href="https://angular-buch.com">Angular-Buch Team</a>
+    &copy;&nbsp;<a href="https://angular-buch.com">Angular-Buch-Team</a>
     <script>
       function resetBookList() {
         const resetOK = document.querySelector('#resetOK');
-        if (!confirm('Do you want to reset the book list?')) {
+        if (!confirm('Buchliste zurücksetzen?')) {
           return;
         }
 
         fetch('/books', { method: 'DELETE' }).then(() => {
           resetOK.style.visibility = 'visible';
-
           setTimeout(() => (resetOK.style.visibility = 'hidden'), 1000);
         });
       }


### PR DESCRIPTION
## Summary
- Alle englischen Texte in `indexpage.html` und `dummycoverspage.php` ins Deutsche übersetzt
- `lang="en"` auf `lang="de"` geändert
- Betrifft UI-Texte, Button-Labels, Confirm-Dialoge und Beschreibungen